### PR TITLE
Update node forge

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
     },
     {
       "name": "Charles Bushong",
-      "email": "bushong1@gmail.com  ",
+      "email": "bushong1@gmail.com",
       "url": "http://github.com/bushong1"
     }
   ],
   "license": "MIT",
   "dependencies": {
-    "node-forge": "0.6.33"
+    "node-forge": "0.7.1"
   },
   "devDependencies": {
     "mocha": "^1.20.1"

--- a/test/tests.js
+++ b/test/tests.js
@@ -33,20 +33,35 @@ describe('generate', function () {
   });
 
   it('should include pkcs7', function (done) {
-    var pems = generate(null, {pkcs7: true});
+    var pems = generate([{ name: 'commonName', value: 'contoso.com' }], {pkcs7: true});
 
     assert.ok(!!pems.pkcs7, 'has a pkcs7');
 
-    try {
-      fs.unlinkSync('/tmp/tmp.crt');
-    } catch(er){}
+		try {
+			fs.unlinkSync('/tmp/tmp.pkcs7');
+		} catch (er) {}
 
-    fs.writeFileSync('/tmp/tmp.crt', pems.cert);
-    exec('openssl crl2pkcs7 -nocrl -certfile /tmp/tmp.crt', function (err, stdout, stderr) {
-      var expected = stdout.toString().replace(/\n/g, '\r\n'); //node-forge uses \r\n
-      assert.equal(pems.pkcs7, expected);
-      done();
-    });
+		fs.writeFileSync('/tmp/tmp.pkcs7', pems.pkcs7);
+		exec('openssl pkcs7 -print_certs -in /tmp/tmp.pkcs7', function (err, stdout, stderr) {
+			if (err) {
+				return done(err);
+			}
+
+			const errorMessage = stderr.toString();
+			if (errorMessage.length) {
+				return done(new Error(errorMessage));
+			}
+
+			const expected = stdout.toString().replace(/\n/g, '\r\n'); //node-forge uses \r\n
+			assert.equal(
+				`subject=/CN=contoso.com\r\nissuer=/CN=contoso.com\r\n` +
+					pems.cert +
+					'\r\n',
+				expected
+			);
+
+			done();
+		});
   });
 
   it('should support sha1 algorithm', function (done) {
@@ -87,20 +102,35 @@ describe('generate', function () {
     });
 
     it('should include pkcs7', function (done) {
-      generate(null, {pkcs7: true}, function (err, pems) {
+      generate([{ name: 'commonName', value: 'contoso.com' }], {pkcs7: true}, function (err, pems) {
         if (err) done(err);
         assert.ok(!!pems.pkcs7, 'has a pkcs7');
 
-        try{
-          fs.unlinkSync('/tmp/tmp.crt');
-        }catch(er){}
+				try {
+					fs.unlinkSync('/tmp/tmp.pkcs7');
+				} catch (er) {}
 
-        fs.writeFileSync('/tmp/tmp.crt', pems.cert);
-        exec('openssl crl2pkcs7 -nocrl -certfile /tmp/tmp.crt', function (err, stdout, stderr) {
-          var expected = stdout.toString().replace(/\n/g, '\r\n'); //node-forge uses \r\n
-          assert.equal(pems.pkcs7, expected);
-          done();
-        });
+				fs.writeFileSync('/tmp/tmp.pkcs7', pems.pkcs7);
+				exec('openssl pkcs7 -print_certs -in /tmp/tmp.pkcs7', function (err, stdout, stderr) {
+					if (err) {
+						return done(err);
+					}
+
+					const errorMessage = stderr.toString();
+					if (errorMessage.length) {
+						return done(new Error(errorMessage));
+					}
+
+					const expected = stdout.toString().replace(/\n/g, '\r\n'); //node-forge uses \r\n
+					assert.equal(
+						`subject=/CN=contoso.com\r\nissuer=/CN=contoso.com\r\n` +
+							pems.cert +
+							'\r\n',
+						expected
+					);
+
+					done();
+				});
       });
     });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -37,31 +37,31 @@ describe('generate', function () {
 
     assert.ok(!!pems.pkcs7, 'has a pkcs7');
 
-		try {
-			fs.unlinkSync('/tmp/tmp.pkcs7');
-		} catch (er) {}
+    try {
+      fs.unlinkSync('/tmp/tmp.pkcs7');
+    } catch (er) {}
 
-		fs.writeFileSync('/tmp/tmp.pkcs7', pems.pkcs7);
-		exec('openssl pkcs7 -print_certs -in /tmp/tmp.pkcs7', function (err, stdout, stderr) {
-			if (err) {
-				return done(err);
-			}
+    fs.writeFileSync('/tmp/tmp.pkcs7', pems.pkcs7);
+    exec('openssl pkcs7 -print_certs -in /tmp/tmp.pkcs7', function (err, stdout, stderr) {
+      if (err) {
+        return done(err);
+      }
 
-			const errorMessage = stderr.toString();
-			if (errorMessage.length) {
-				return done(new Error(errorMessage));
-			}
+      const errorMessage = stderr.toString();
+      if (errorMessage.length) {
+        return done(new Error(errorMessage));
+      }
 
-			const expected = stdout.toString().replace(/\n/g, '\r\n'); //node-forge uses \r\n
-			assert.equal(
-				`subject=/CN=contoso.com\r\nissuer=/CN=contoso.com\r\n` +
-					pems.cert +
-					'\r\n',
-				expected
-			);
+      const expected = stdout.toString().replace(/\n/g, '\r\n'); //node-forge uses \r\n
+      assert.equal(
+        `subject=/CN=contoso.com\r\nissuer=/CN=contoso.com\r\n` +
+          pems.cert +
+          '\r\n',
+        expected
+      );
 
-			done();
-		});
+      done();
+    });
   });
 
   it('should support sha1 algorithm', function (done) {
@@ -106,31 +106,31 @@ describe('generate', function () {
         if (err) done(err);
         assert.ok(!!pems.pkcs7, 'has a pkcs7');
 
-				try {
-					fs.unlinkSync('/tmp/tmp.pkcs7');
-				} catch (er) {}
+        try {
+          fs.unlinkSync('/tmp/tmp.pkcs7');
+        } catch (er) {}
 
-				fs.writeFileSync('/tmp/tmp.pkcs7', pems.pkcs7);
-				exec('openssl pkcs7 -print_certs -in /tmp/tmp.pkcs7', function (err, stdout, stderr) {
-					if (err) {
-						return done(err);
-					}
+        fs.writeFileSync('/tmp/tmp.pkcs7', pems.pkcs7);
+        exec('openssl pkcs7 -print_certs -in /tmp/tmp.pkcs7', function (err, stdout, stderr) {
+          if (err) {
+            return done(err);
+          }
 
-					const errorMessage = stderr.toString();
-					if (errorMessage.length) {
-						return done(new Error(errorMessage));
-					}
+          const errorMessage = stderr.toString();
+          if (errorMessage.length) {
+            return done(new Error(errorMessage));
+          }
 
-					const expected = stdout.toString().replace(/\n/g, '\r\n'); //node-forge uses \r\n
-					assert.equal(
-						`subject=/CN=contoso.com\r\nissuer=/CN=contoso.com\r\n` +
-							pems.cert +
-							'\r\n',
-						expected
-					);
+          const expected = stdout.toString().replace(/\n/g, '\r\n'); //node-forge uses \r\n
+          assert.equal(
+            `subject=/CN=contoso.com\r\nissuer=/CN=contoso.com\r\n` +
+              pems.cert +
+              '\r\n',
+            expected
+          );
 
-					done();
-				});
+          done();
+        });
       });
     });
 


### PR DESCRIPTION
This PR will update node-forge to the latest 0.7 release in order to fix this kind of error with the self signed certificates: https://github.com/openssl/openssl/issues/4320

Steps to reproduce can be found here: https://gist.github.com/sandrinodimattia/8ef6094325e7254473a16925898ab0a1

Running the script with node-forge@0.6.33 results in this type of output (it can take some time before the error shows):

```
Validating 4
Validating 5
Validating 6
Validating 7
Validating 8
Validating 9
Validating 10
Validating 11
Validating 12
Validating 13
Validating 14
Validating 15
Validating 16
Validating 17
Validating 18
Validating 19
Validating 20
Validating 21
unable to load certificate
140735992324928:error:0D0E20DD:asn1 encoding routines:c2i_ibuf:illegal padding:crypto/asn1/a_int.c:187:
140735992324928:error:0D08303A:asn1 encoding routines:asn1_template_noexp_d2i:nested asn1 error:crypto/asn1/tasn_dec.c:609:Field=serialNumber, Type=X509_CINF
140735992324928:error:0D08303A:asn1 encoding routines:asn1_template_noexp_d2i:nested asn1 error:crypto/asn1/tasn_dec.c:609:Field=cert_info, Type=X509
140735992324928:error:0906700D:PEM routines:PEM_ASN1_read_bio:ASN1 lib:crypto/pem/pem_oth.c:33:
```

Now with the node-forge update to 0.7.1 there are no errors at all (after generating and validating 10.000 certs)

> Note: I had to update the tests for pkcs7. The output from node-forge and OpenSSL 1.1 is slightly different, so instead of just comparing the output I use OpenSSL to convert the pkcs7 file to a cert and compare that cert to the generated cert.