### PR TITLE
Fixes broken Link to X.509 Attributes Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Will return the following like this:
 
 ## Attributes
 
-for attributes, please refer to: https://github.com/digitalbazaar/forge/blob/master/js/x509.js#L121
+for attributes, please refer to: https://github.com/digitalbazaar/forge/blob/master/lib/x509.js#L129
 
 ## Options
 


### PR DESCRIPTION
The location of the x509.js file changed from js/x509.js#L121 to lib/x509.js#L129.