### PR TITLE
chore: update node-forge dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "node-forge": "^0.9.1"
+    "node-forge": "^0.10.0"
   },
   "devDependencies": {
     "mocha": "^5.1.1"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "node-forge": "0.9.0"
+    "node-forge": "^0.9.1"
   },
   "devDependencies": {
     "mocha": "^5.1.1"


### PR DESCRIPTION
The latest version of node-forge is `0.9.1` but this module has it pinned at `0.9.0` meaning if you have another dependency that uses node-forge and you're building for the browser, you'll get two copies of it in your bundle and node-forge is big!

This change uses `^` to select non-breaking semver ranges and merging it would be helpful to keep bundle sizes down.