### PR TITLE
Allow to use private CA certificate and key pair to issue certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,47 @@ To override the default client CN of `john doe jdoe123`, add another option for 
 var pems = selfsigned.generate(null, { clientCertificate: true, clientCertificateCN: 'FooBar' });
 ```
 
+### Generate certificates signed by your own CA
+
+Provide your private certificate authority root certificate and private key in PEM format in `ca` option object (under `cert` and `private` keys respectively):
+
+```js
+const cert = selfsigned.generate(
+  [{ name: 'commonName',  value: 'example.com' }],
+  {
+    keySize: 2048,
+    ca: {
+      cert:    "-----BEGIN CERTIFICATE-----\r\n…\r\n-----END CERTIFICATE-----\r\n",
+      private: "-----BEGIN RSA PRIVATE KEY-----\r\n…\r\n-----END RSA PRIVATE KEY-----\r\n",
+    },
+    algorithm: 'sha256',
+    extensions: [
+      {
+        name: 'basicConstraints',
+        cA: false,
+      },
+      {
+        name: "keyUsage",
+        keyCertSign: false, // Must be set to false or Chrome won't accept this certificate otherwise
+        digitalSignature: true,
+        nonRepudiation: true,
+        keyEncipherment: true,
+        dataEncipherment: true,
+      },
+      {
+        name: "extKeyUsage",
+        serverAuth: true,
+        clientAuth: true,
+        codeSigning: true,
+        timeStamping: true,
+      },
+    ],
+  }
+)
+```
+
+And yes, you can generate CA certificate with selfsigned itself and just provide output of `selfsigned.generate` into `ca` option.
+
 ## License
 
 MIT


### PR DESCRIPTION
Fixes https://github.com/jfromaniello/selfsigned/issues/13

What's inside:
 - [x] Code
 - [x] Readme
 - [ ] Tests (I will write some when you will be okay with API)

**What's changed**

Receive optional `ca` option object into `generate` with your own Certificate Authority certificate and private key used to sign certificates.

**How to use it**

 1. Generate CA keypair with selfsigned itself

    ```js
    const selfsigned = require('selfsigned')
    const fs = require('fs-extra')

    const rootCA = selfsigned.generate(
      [
        { name: 'commonName', value: 'Development Certificate Authority' },
        { name: 'countryName', value: 'RU' },
        { name: 'organizationName', value: 'Evil Martians' }, 
      ],
      {
        keySize: 2048,
        algorithm: 'sha256',
        extensions: [
          {
            name: 'basicConstraints',
            cA: true,
          },
        ]
      }
    )

    // Import ca.crt into your browsers:
    // - Chrome: chrome://settings/certificates at Authorities tab
    // - Firefox: about:preferences#privacy, Certificates, View certificates, Authorities tab
    fs.writeFileSync('./ca.crt', rootCA.cert)
    ```

 2. Generate certificate signed by this CA

    ```js
    const cert = selfsigned.generate(
      [
        { name: 'commonName',  value: 'Our cool service' },
        { name: 'countryName', value: 'RU' },
        { name: 'organizationName', value: 'Evil Martians' }, 
      ],
      {
        keySize: 2048,
        ca: rootCA,
        algorithm: 'sha256',
        extensions: [
          {
            name: 'basicConstraints',
            cA: false,
          },
          {
            name: "keyUsage",
            keyCertSign: false,  // Must be set to false or Chrome won't accept this certificate otherwise
            digitalSignature: true,
            nonRepudiation: true,
            keyEncipherment: true,
            dataEncipherment: true,
          },
          {
            name: "extKeyUsage",
            serverAuth: true,
            clientAuth: true,
            codeSigning: true,
            timeStamping: true,
          },
          {
            name: "subjectAltName",
            altNames: [
              {
                // type 2 is DNS
                type: 2,
                value: "localhost",
              },
              {
                type: 2,
                value: "localhost.localdomain",
              },
              {
                type: 2,
                value: "evilmartians.com",
              },
              {
                // type 7 is IP
                type: 7,
                ip: "127.0.0.1",
              },
            ],
          },
        ],
      }
    )
    ```

 3. Test it!

    ```js
    const https = require('https')
    const app = require('express')()

    app.get('/', (req, res) => res.send('ok'))

    const httpsServer = https.createServer(
      {
        key: cert.private,
        cert: cert.cert,
      },
      app
    )
    httpsServer.listen(4443)
    ```

What do you think?