### PR TITLE
update node-forge dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "selfsigned",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "description": "Generate self signed certificates private and public keys",
   "main": "index.js",
   "scripts": {
@@ -31,7 +31,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "node-forge": "^1"
+    "node-forge": "^1.3.0"
   },
   "devDependencies": {
     "chai": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "node-forge": "^1.3.0"
+    "node-forge": "^1.3.1"
   },
   "devDependencies": {
     "chai": "^4.3.4",


### PR DESCRIPTION
I am trying to use the `storybook-addon-playroom` which has dependencies on `selfsigned`. We have a security tool that checks for vulnerabilities and we see that the existing version of `node-forge` used currently poses the vulnerabilities below.

https://security.snyk.io/vuln/SNYK-JS-NODEFORGE-2430337
https://security.snyk.io/vuln/SNYK-JS-NODEFORGE-2430339
https://security.snyk.io/vuln/SNYK-JS-NODEFORGE-2430341

Updated the `node-forge` dependency to `1.3.1` .

I have made a fix and made sure all the test cases in `selfsigned` passes.
It would be of great help if you could please look into this and expedite the process.
Thanks in advance.
@jfromaniello Please let me know if anything else if needed from my end.

