### PR TITLE
adding client cert key size option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,11 @@ declare interface SelfsignedOptions {
    * @default "John Doe jdoe123"
    */
   clientCertificateCN?: string
+  /**
+   * the size for the client private key in bits
+   * @default 1024
+   */
+   clientCertificateKeySize?: number
 }
 
 declare interface GenerateResult {

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ exports.generate = function generate(attrs, options, done) {
     }
 
     if (options && options.clientCertificate) {
-      var clientkeys = forge.pki.rsa.generateKeyPair(1024);
+      var clientkeys = forge.pki.rsa.generateKeyPair(options.clientCertificateKeySize || 1024);
       var clientcert = forge.pki.createCertificate();
       clientcert.serialNumber = toPositiveHex(forge.util.bytesToHex(forge.random.getBytesSync(9)));
       clientcert.validity.notBefore = new Date();


### PR DESCRIPTION
The key size for the client is hardcoded as 1024 however in the case of PS256 this needs to be at least 2048