### PR TITLE
Add @types/node-forge dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
+        "@types/node-forge": "^1.3.0",
         "node-forge": "^1"
       },
       "devDependencies": {
@@ -17,6 +18,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.7.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.21.tgz",
+      "integrity": "sha512-rLFzK5bhM0YPyCoTC8bolBjMk7bwnZ8qeZUBslBfjZQou2ssJdWslx9CZ8DGM+Dx7QXQiiTVZ/6QO6kwtHkZCA=="
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.0.tgz",
+      "integrity": "sha512-yUsIEHG3d81E2c+akGjZAMdVcjbfqMzpMjvpebnTO7pEGfqxCtBzpRV52kR1RETtwJ9fHkLdEjtaM+uMKWpwFA==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -1103,6 +1117,19 @@
     }
   },
   "dependencies": {
+    "@types/node": {
+      "version": "18.7.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.21.tgz",
+      "integrity": "sha512-rLFzK5bhM0YPyCoTC8bolBjMk7bwnZ8qeZUBslBfjZQou2ssJdWslx9CZ8DGM+Dx7QXQiiTVZ/6QO6kwtHkZCA=="
+    },
+    "@types/node-forge": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.0.tgz",
+      "integrity": "sha512-yUsIEHG3d81E2c+akGjZAMdVcjbfqMzpMjvpebnTO7pEGfqxCtBzpRV52kR1RETtwJ9fHkLdEjtaM+uMKWpwFA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@types/node-forge": "^1.3.0",
     "node-forge": "^1"
   },
   "devDependencies": {


### PR DESCRIPTION
The new `selfsigned` types reference `node-forge`, but since `@types/node-forge` isn't listed as a dependency, users will hit the following error:

```
node_modules/selfsigned/index.d.ts:1:21 - error TS7016: Could not find a declaration file for module 'node-forge'. '/home/aomarks/work/wireit/node_modules/node-forge/lib/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/node-forge` if it exists or add a new declaration (.d.ts) file containing `declare module 'node-forge';`

1 import { pki } from 'node-forge'
                      ~~~~~~~~~~~~
```

Adding the dependency solves that problem.

Thank you!