### PR TITLE
Add support for overriding notBeforeDate

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ for attributes, please refer to: https://github.com/digitalbazaar/forge/blob/mas
 var pems = selfsigned.generate(null, {
   keySize: 2048, // the size for the private key in bits (default: 1024)
   days: 30, // how long till expiry of the signed certificate (default: 365)
+  notBeforeDate: new Date(), // The date before which the certificate should not be valid (default: now)
   algorithm: 'sha256', // sign the certificate with specified algorithm (default: 'sha1')
   extensions: [{ name: 'basicConstraints', cA: true }], // certificate extensions array
   pkcs7: true, // include PKCS#7 as part of the output (default: false)

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,13 @@ declare interface SelfsignedOptions {
    *
    * @default 365 */
   days?: number
+
+  /**
+   * The date before which the certificate should not be valid
+   *
+   * @default now */
+  notBeforeDate?: Date
+
   /**
    * the size for the private key in bits
    * @default 1024

--- a/index.js
+++ b/index.js
@@ -53,9 +53,10 @@ exports.generate = function generate(attrs, options, done) {
 
     cert.serialNumber = toPositiveHex(forge.util.bytesToHex(forge.random.getBytesSync(9))); // the serial number can be decimal or hex (if preceded by 0x)
 
-    cert.validity.notBefore = options.notBeforeDate || new Date();
-    cert.validity.notAfter = new Date();
-    cert.validity.notAfter.setDate(cert.validity.notBefore.getDate() + (options.days || 365));
+    var now = new Date();
+    cert.validity.notBefore = options.notBeforeDate || now;
+    cert.validity.notAfter = now;
+    cert.validity.notAfter.setDate(now.getDate() + (options.days || 365));
 
     attrs = attrs || [{
       name: 'commonName',

--- a/index.js
+++ b/index.js
@@ -53,10 +53,11 @@ exports.generate = function generate(attrs, options, done) {
 
     cert.serialNumber = toPositiveHex(forge.util.bytesToHex(forge.random.getBytesSync(9))); // the serial number can be decimal or hex (if preceded by 0x)
 
-    var now = new Date();
-    cert.validity.notBefore = options.notBeforeDate || now;
-    cert.validity.notAfter = now;
-    cert.validity.notAfter.setDate(now.getDate() + (options.days || 365));
+    cert.validity.notBefore = options.notBeforeDate || new Date();
+
+    var notAfter = new Date();
+    cert.validity.notAfter = notAfter;
+    cert.validity.notAfter.setDate(notAfter.getDate() + (options.days || 365));
 
     attrs = attrs || [{
       name: 'commonName',

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ exports.generate = function generate(attrs, options, done) {
 
     cert.serialNumber = toPositiveHex(forge.util.bytesToHex(forge.random.getBytesSync(9))); // the serial number can be decimal or hex (if preceded by 0x)
 
-    cert.validity.notBefore = new Date();
+    cert.validity.notBefore = options.notBeforeDate || new Date();
     cert.validity.notAfter = new Date();
     cert.validity.notAfter.setDate(cert.validity.notBefore.getDate() + (options.days || 365));
 


### PR DESCRIPTION
We had some need to set the notBeforeDate on our certificates. Specifically when generating self-signed certificates for use on remote systems who's clock skew may be big enough that the notBeforeDate on the generating machine is in the future for the remote machine.

I decided to use a date type as input here since you may want more granularity than 'days in the past' for this value.