### PR TITLE
Update node-forge to 1.3.2.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -797,9 +797,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
+      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"


### PR DESCRIPTION
- [node-forge@1.3.2](https://github.com/digitalbazaar/forge/blob/main/CHANGELOG.md#132---2025-11-25) released today with some security advisories that will likely trigger alerts.
- Out of curiosity, is there a reason the full version is not used in package.json?